### PR TITLE
fix: split attendance data by record size

### DIFF
--- a/zk/base.py
+++ b/zk/base.py
@@ -1646,6 +1646,7 @@ class ZK(object):
                 attendance = Attendance(user_id, timestamp, status, punch, uid)
                 attendances.append(attendance)
         else:
+            record_size_int = int(record_size)
             while len(attendance_data) >= 40:
                 uid, user_id, status, timestamp, punch, space = unpack('<H24sB4sB8s', attendance_data.ljust(40, b'\x00')[:40])
                 if self.verbose: print (codecs.encode(attendance_data[:40], 'hex'))
@@ -1654,7 +1655,7 @@ class ZK(object):
 
                 attendance = Attendance(user_id, timestamp, status, punch, uid)
                 attendances.append(attendance)
-                attendance_data = attendance_data[40:]
+                attendance_data = attendance_data[record_size_int:]
         return attendances
 
     def clear_attendance(self):


### PR DESCRIPTION
When `record_size` is greater than or equal to 40, we should be splitting the data by the `record_size` and not by 40.

In my case, the record size was 49, splitting by 40 gave me useless data.