### PR TITLE
Add iClock700/ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,10 @@ DeviceName       : F18/ID
 Firmware Version : Ver 6.60 May 25 2018
 Platform         : JZ4725_TFT
 DeviceName       : K40/ID
+
+Firmware Version : Ver 6.60 May 14 2018
+Platform         : ZMM200_TFT
+DeviceName       : iClock700/ID
 ```
 
 


### PR DESCRIPTION
SDK build=1      : True
Disabling device ...
ExtendFmt        : None
UsrExtFmt        : 0
Face FunOn       : 0
Face Version     : 7
Finger Version   : 10
Old Firm compat  : 0
IP:192.168.1.201 mask:255.255.255.0 gateway:0.0.0.0
Time             : 2023-03-27 10:37:43
Firmware Version : Ver 6.60 May 14 2018
Platform         : ZMM200_TFT
DeviceName       : iClock700/ID
Pin Width        : 9
Serial Number    : ***
MAC: ***

--- sizes & capacity ---
ZK tcp://192.168.0.105:4370 users[1]:1/50000 fingers:1/50000, records:0/800000 faces:0/0