### PR TITLE
docs: add Debian PEP 668 virtual environment setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,19 @@ There is some installation method you can use below:
 ```sh
 pip install -U pyzk
 ```
+### Debian/Ubuntu (PEP 668)
+
+On modern Debian-based systems the above command may fail with:
+
+    error: externally-managed-environment
+
+This is enforced by PEP 668 to protect system Python packages.
+Use a virtual environment instead:
+
+    sudo apt install python3-venv -y
+    python3 -m venv venv
+    source venv/bin/activate
+    pip install pyzk
 
 * manual installation (clone and execute)
 


### PR DESCRIPTION
## Description

This PR adds a documentation section to the README covering the installation process on modern Debian/Ubuntu systems, where the standard `pip install pyzk` command fails due to PEP 668 enforcement.

## Problem

On Debian-based distributions, attempting to install pyzk globally produces the following error:

```
error: externally-managed-environment
```

This is not a bug in pyzk — it is a deliberate system-level restriction introduced by PEP 668 to protect system Python packages from conflicts with user-installed libraries. However, it is not currently documented, which may confuse developers coming from Windows or older Linux environments.

## Solution

Added a dedicated subsection under **Installation** explaining the cause of the error and providing the recommended workaround using a Python virtual environment:

```bash
sudo apt install python3-venv -y
python3 -m venv venv
source venv/bin/activate
pip install pyzk
```

## Context

This was encountered while integrating a **ZKTeco LX14** biometric terminal on a Debian virtual machine. The virtual environment approach was validated in a real-world setup and worked as expected.

## Changes
- `README.md` — added Debian/Ubuntu installation subsection under the existing Installation section

## Notes
No code changes were made. This is a documentation-only contribution.